### PR TITLE
added Levers & Redstone Torches to Explosion Whitelist

### DIFF
--- a/src/main/java/com/johnymuffin/beta/tntcontrol/ExplosionControl.java
+++ b/src/main/java/com/johnymuffin/beta/tntcontrol/ExplosionControl.java
@@ -29,11 +29,11 @@ public class ExplosionControl extends JavaPlugin {
            Material.SAPLING, Material.LOG, Material.LEAVES, Material.DEAD_BUSH, Material.YELLOW_FLOWER,
            Material.RED_ROSE, Material.RED_MUSHROOM, Material.BROWN_MUSHROOM, Material.TORCH, Material.SNOW,
            Material.CACTUS, Material.CLAY, Material.SUGAR_CANE_BLOCK, Material.ICE, Material.TNT, Material.FIRE,
-           Material.LAVA, Material.WATER, Material.STATIONARY_LAVA, Material.STATIONARY_WATER));
+           Material.LAVA, Material.WATER, Material.STATIONARY_LAVA, Material.STATIONARY_WATER, Material.LEVER,
+           Material.REDSTONE_TORCH_OFF, Material.REDSTONE_TORCH_ON));
 
    public static final Set<Material> blockBlacklist = new HashSet<>(Arrays.asList(Material.DIODE_BLOCK_OFF, Material.DIODE_BLOCK_ON,
-           Material.STONE_BUTTON, Material.LEVER, Material.RAILS, Material.DETECTOR_RAIL, Material.POWERED_RAIL,
-           Material.REDSTONE_WIRE, Material.REDSTONE_TORCH_OFF, Material.REDSTONE_TORCH_ON, Material.SIGN_POST,
+           Material.STONE_BUTTON, Material.RAILS, Material.DETECTOR_RAIL, Material.POWERED_RAIL, Material.REDSTONE_WIRE, Material.SIGN_POST,
            Material.WOOD_PLATE, Material.STONE_PLATE, Material.WOODEN_DOOR, Material.IRON_DOOR_BLOCK, Material.CAKE_BLOCK,
            Material.WALL_SIGN, Material.TRAP_DOOR, Material.LADDER, Material.SUGAR_CANE_BLOCK, Material.WATER, Material.STATIONARY_WATER,
            Material.LAVA, Material.STATIONARY_LAVA, Material.SAPLING));


### PR DESCRIPTION
Levers and Redstone Torches will now be able to be blown up by TNT.

I've seen many frustrated players trying to ignite TNT with levers or redstone torches, only to have their TNT disappear and leave them confused.

Blocks like redstone wire and repeaters still remain on the blacklist, so redstone contraptions should still be protected after these changes.